### PR TITLE
Added render-props code example

### DIFF
--- a/react/rener-props/content.txt
+++ b/react/rener-props/content.txt
@@ -1,0 +1,47 @@
+import React from 'react'
+
+const MOBILE_VIEW_WIDTH_THRESHOLD = 600;
+
+class MediaQuery {
+    state = {
+        shouldShowMobileView: false
+    }
+
+    componentDidMount() {
+        addEventListener('resize', this.updateResizeStatus);
+    }
+
+    componentWillUnmount() {
+        removeEventListener('resize', this.updateResizeStatus);
+    }
+
+    updateResizeStatus() {
+        if (screen.width <= MOBILE_VIEW_WIDTH_THRESHOLD) {
+            this.setState({
+                shouldShowMobileView: true
+            });
+        }
+    }
+
+    render() {
+        return this.props.children(this.state.shouldShowMobileView);
+    }
+}
+
+export default MediaQuery;
+
+// --------
+
+import React from 'react'
+import MobileView from '../components/MobileView'
+import DefaultView from '../components/DefaultView'
+
+const Screen = () => (
+    <MediaQuery>
+        {
+            (shouldShowMobileView) => shouldShowMobileView
+                ? <MobileView />
+                : <DefaultView />
+        }
+    </MediaQuery>
+)

--- a/react/rener-props/metadata.json
+++ b/react/rener-props/metadata.json
@@ -1,0 +1,7 @@
+{
+  "title": "Render Props",
+  "file": "content.txt",
+  "type": "language-jsx",
+  "author": "Daler Asrorov",
+  "authorLink": "https://github.com/DalerAsrorov"
+}


### PR DESCRIPTION
As discussed in https://github.com/leon-good-life/developer-cheatsheets/issues/1, I wanted to add a `render-props` example. Added an example with a good use case for it. Would appreciate your review and merge. Thanks a lot!