### PR TITLE
Removing use of 'this' inside a stateless component

### DIFF
--- a/react/hoc/content.txt
+++ b/react/hoc/content.txt
@@ -6,7 +6,7 @@ const withLoading = WrappedComponent => {
     if (props.isLoading) {
       return <Loading />
     }
-    return <WrappedComponent {...this.props} />
+    return <WrappedComponent {...props} />
   }
 }
 


### PR DESCRIPTION
'this' should not be used inside a stateless component